### PR TITLE
Add quality declaration documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+Any contribution that you make to this repository will
+be under the Apache 2 License, as dictated by that
+[license](http://www.apache.org/licenses/LICENSE-2.0.html):
+
+~~~
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+~~~
+
+Contributors must sign-off each commit by adding a `Signed-off-by: ...`
+line to commit messages to certify that they have the right to submit
+the code they are contributing to the project according to the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).

--- a/rmf_utils/QUALITY_DECLARATION.md
+++ b/rmf_utils/QUALITY_DECLARATION.md
@@ -97,13 +97,14 @@ The tests are not run automatically.
 
 ### Public API Testing [4.ii]
 
-`rmf_utils` contains partial tests for some of its public API.
-The tests are not run automatically.
-The API is not completely covered by tests.
+Each part of the public API has tests, and new additions or changes to the public API require tests before being added.
+They are located in the [`test`](https://github.com/open-rmf/rmf_utils/tree/master/rmf_utils/test) directory.
 
 ### Coverage [4.iii]
 
-`rmf_utils` does not track coverage statistics.
+`rmf_utils` tracks code coverage statistics. There is no coverage target currently, but new changes are required to make a best effort to keep or increase coverage before being accepted. Decreases are allowed if properly justified and accepted by reviewers. Code coverage will be improved in the future as time allows.
+
+Current coverage statistics can be viewed [here](https://codecov.io/gh/open-rmf/rmf_utils).
 
 ### Performance [4.iv]
 

--- a/rmf_utils/QUALITY_DECLARATION.md
+++ b/rmf_utils/QUALITY_DECLARATION.md
@@ -48,7 +48,7 @@ The generated CMake config file is installed and therefore part of the public AP
 
 ### Contributor Origin [2.ii]
 
-`rmf_utils` does not require a confirmation of contributor origin.
+`rmf_utils` uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
 
 ### Peer Review Policy [2.iii]
 
@@ -132,7 +132,7 @@ The API is not completely covered by tests.
 ### Target platforms [6.i]
 
 `rmf_utils` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
-`rmf_utils` supports ROS Eloquent.
+`rmf_utils` supports ROS Foxy.
 
 ## Security [7]
 

--- a/rmf_utils/QUALITY_DECLARATION.md
+++ b/rmf_utils/QUALITY_DECLARATION.md
@@ -1,0 +1,141 @@
+This document is a declaration of software quality for the `rmf_utils` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_utils` Quality Declaration
+
+The package `rmf_utils` claims to be in the **Quality Level 4** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_utils` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_utils` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All symbols in the installed headers are considered part of the public API.
+
+All installed headers are in the `include` directory of the package.
+Headers in any other folders are not installed and are considered private.
+
+The generated CMake config file is installed and therefore part of the public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_utils` will not break public API within a major version number.
+
+### ABI Stability Policy [1.v]
+
+`rmf_utils` will not break public ABI within a major version number.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_utils` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
+
+## Change Control Process [2]
+
+`rmf_utils` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_utils` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_utils` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+The most recent CI results can be seen on [the workflow page](https://github.com/open-rmf/rmf_utils/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_utils` does not provide documentation.
+
+### Public API Documentation [3.ii]
+
+`rmf_utils` has some embedded API documentation, but it is not hosted.
+
+### License [3.iii]
+
+The license for `rmf_utils` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_utils`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_utils` contains partial tests for some of its features.
+The tests are not run automatically.
+
+### Public API Testing [4.ii]
+
+`rmf_utils` contains partial tests for some of its public API.
+The tests are not run automatically.
+The API is not completely covered by tests.
+
+### Coverage [4.iii]
+
+`rmf_utils` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`rmf_utils` does not test performance.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_utils` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_utils` has no required runtime dependencies.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_utils` has no optional runtime dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_utils` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+### Target platforms [6.i]
+
+`rmf_utils` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`rmf_utils` supports ROS Eloquent.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_utils/QUALITY_DECLARATION.md
+++ b/rmf_utils/QUALITY_DECLARATION.md
@@ -48,7 +48,8 @@ The generated CMake config file is installed and therefore part of the public AP
 
 ### Contributor Origin [2.ii]
 
-`rmf_utils` uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+`rmf_utils` uses DCO as its confirmation of contributor origin policy.
+More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
 
 ### Peer Review Policy [2.iii]
 

--- a/rmf_utils/README.md
+++ b/rmf_utils/README.md
@@ -1,0 +1,7 @@
+# rmf_utils
+
+`rmf_utils` provides simple C++ programming utilities used by Robotics Middleware Framework packages
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.


### PR DESCRIPTION
This PR adds [quality declaration documents](https://www.ros.org/reps/rep-2004.html) and (where necessary) basic README files too all packages in `rmf_utils`.

All source-code-containing packages are currently QL4.