### PR TITLE
install rmf_code_style.cfg in rmf_utils_DIR

### DIFF
--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -104,5 +104,5 @@ endif()
 install(
   FILES
     test/format/rmf_code_style.cfg
-  DESTINATION lib/${PROJECT_NAME}/cmake
+  DESTINATION share/${PROJECT_NAME}
 )

--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -71,6 +71,12 @@ export(
   NAMESPACE rmf_utils::
 )
 
+install(
+  FILES
+    test/format/rmf_code_style.cfg
+  DESTINATION lib/${PROJECT_NAME}/cmake
+)
+
 export(PACKAGE rmf_utils-targets)
 
 find_package(ament_cmake REQUIRED)

--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -71,12 +71,6 @@ export(
   NAMESPACE rmf_utils::
 )
 
-install(
-  FILES
-    test/format/rmf_code_style.cfg
-  DESTINATION lib/${PROJECT_NAME}/cmake
-)
-
 export(PACKAGE rmf_utils-targets)
 
 find_package(ament_cmake REQUIRED)
@@ -106,3 +100,9 @@ if(BUILD_TESTING AND ament_cmake_catch2_FOUND)
     MAX_LINE_LENGTH 80
   )
 endif()
+
+install(
+  FILES
+    test/format/rmf_code_style.cfg
+  DESTINATION lib/${PROJECT_NAME}/cmake
+)


### PR DESCRIPTION
### Implemented feature

Installs the cfg file for use in other repositories via `${rmf_utils_DIR}` macro
