### PR TITLE
Changed package requirement to QUIET to allow use in non-ROS 2 packages

### DIFF
--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -73,9 +73,9 @@ export(
 
 export(PACKAGE rmf_utils-targets)
 
-find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_catch2 REQUIRED)
-if(BUILD_TESTING AND ament_cmake_catch2_FOUND)
+find_package(ament_cmake_catch2 QUIET)
+find_package(rmf_cmake_uncrustify QUIET)
+if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND rmf_cmake_uncrustify_FOUND)
   file(GLOB_RECURSE unit_test_srcs "test/*.cpp")
   
   ament_add_catch2(
@@ -89,7 +89,6 @@ if(BUILD_TESTING AND ament_cmake_catch2_FOUND)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
   )
 
-  find_package(rmf_cmake_uncrustify REQUIRED)
   find_file(uncrustify_config_file 
     NAMES "rmf_code_style.cfg"
     PATHS "test/format/")

--- a/rmf_utils/package.xml
+++ b/rmf_utils/package.xml
@@ -10,7 +10,6 @@
 
   <build_depend>cmake</build_depend>
 
-  <test_depend>ament_cmake</test_depend>
   <test_depend>ament_cmake_catch2</test_depend>
   <test_depend>rmf_cmake_uncrustify</test_depend>
 


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## New feature implementation

### Implemented feature

<!-- Briefly describe the feature being implemented.
If there is a feature request issue for the feature, link to that feature.
If there is not a feature request issue for the feature, create one first and fill out all the required information there, then link to that issue from this new feature pull request. -->

Implements this request, https://github.com/open-rmf/rmf_utils/issues/5.

### Implementation description

<!-- Describe the approach taken to implement the feature.
Provide a link to a detailed design document and discussion of that design.
Implementations without design documentation will not be accepted until design documentation has been provided and discussed.
Usually this is done via the feature request issue. -->

Only built tests when both `ament_cmake_catch2` and `rmf_cmake_uncrustify` is found.
