### PR TITLE
Adding missing string include for test, only shows up when compiling with clang

### DIFF
--- a/rmf_utils/test/unit/TestClass.hpp
+++ b/rmf_utils/test/unit/TestClass.hpp
@@ -18,6 +18,7 @@
 #ifndef RMF_UTILS__TEST__UNIT__TESTCLASS_HPP
 #define RMF_UTILS__TEST__UNIT__TESTCLASS_HPP
 
+#include <string>
 #include <rmf_utils/impl_ptr.hpp>
 
 class TestClass


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

* `rmf_utils` build fails when using `clang`, here is the gist, https://gist.github.com/aaronchongth/b68b8600075efc172075fe784d63306e
* Tested in a separate branch with a clang workflow, https://github.com/open-rmf/rmf_utils/compare/ci/clang