### PR TITLE
the CMake user package registry can do unexpected things.

### DIFF
--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -71,8 +71,6 @@ export(
   NAMESPACE rmf_utils::
 )
 
-export(PACKAGE rmf_utils-targets)
-
 find_package(ament_cmake_catch2 QUIET)
 find_package(rmf_cmake_uncrustify QUIET)
 if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND rmf_cmake_uncrustify_FOUND)


### PR DESCRIPTION
The CMake user package registry can cause unexpected behavior if people aren't accustomed to it. This PR removes the `export(PACKAGE ...)` invocation that adds to the user package registry in `~/.cmake/packages` during the `colcon` build/install process.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>