### PR TITLE
Use ament_cmake_uncrustify

### DIFF
--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -72,10 +72,10 @@ export(
 )
 
 find_package(ament_cmake_catch2 QUIET)
-find_package(rmf_cmake_uncrustify QUIET)
-if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND rmf_cmake_uncrustify_FOUND)
+find_package(ament_cmake_uncrustify QUIET)
+if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND ament_cmake_uncrustify_FOUND)
   file(GLOB_RECURSE unit_test_srcs "test/*.cpp")
-  
+
   ament_add_catch2(
     test_rmf_utils test/main.cpp ${unit_test_srcs}
     TIMEOUT 300)
@@ -87,11 +87,11 @@ if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND rmf_cmake_uncrustify_FOUND)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
   )
 
-  find_file(uncrustify_config_file 
+  find_file(uncrustify_config_file
     NAMES "rmf_code_style.cfg"
     PATHS "test/format/")
 
-  rmf_uncrustify(
+  ament_uncrustify(
     ARGN include src test
     CONFIG_FILE ${uncrustify_config_file}
     MAX_LINE_LENGTH 80

--- a/rmf_utils/package.xml
+++ b/rmf_utils/package.xml
@@ -12,7 +12,7 @@
   <build_depend>cmake</build_depend>
 
   <test_depend>ament_cmake_catch2</test_depend>
-  <test_depend>rmf_cmake_uncrustify</test_depend>
+  <test_depend>ament_cmake_uncrustify</test_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
We currently have the rmf_cmake_uncrustify package that is used for style checking with colcon test. The original reason for having this package and not using ament_cmake_uncrustify was that the latter did not support custom uncrustify configuration files. But this feature was [merged upstream](https://github.com/ament/ament_lint/pull/200) quite a while ago and has been part of `foxy` and `galactic` releases. Hence, switching back to `ament_cmake_uncrustify` for ease of maintenance and distribution.