### PR TITLE
Add a class to help with limiting rates of events

### DIFF
--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.0)
 project(rmf_utils VERSION 1.3.0)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -12,10 +12,11 @@ endif()
 
 include(GNUInstallDirs)
 
-add_library(rmf_utils INTERFACE)
+file(GLOB_RECURSE lib_srcs "src/rmf_utils/*.cpp")
+add_library(rmf_utils SHARED ${lib_srcs})
 
 target_include_directories(rmf_utils
-  INTERFACE
+  PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )

--- a/rmf_utils/include/rmf_utils/RateLimiter.hpp
+++ b/rmf_utils/include/rmf_utils/RateLimiter.hpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef RMF_UTILS__RATELIMITER_HPP
+#define RMF_UTILS__RATELIMITER_HPP
+
+#include <chrono>
+
+#include <rmf_utils/impl_ptr.hpp>
+
+namespace rmf_utils {
+
+//==============================================================================
+/// A class used to track limits in the rate at which an event may occur. A
+/// counter will increment each time reached_limit() is called within a time
+/// period.
+///
+/// If the counter reaches its limit then reached_limit() will return true.
+///
+/// If the counter has not reached its limit then reached_limit() will return
+/// false.
+///
+/// If reached_limit() is called again after the period limit has passed, then
+/// the time period will be reset and the function will return false.
+class RateLimiter
+{
+public:
+
+  /// Constructor
+  ///
+  /// \param[in] period_limit_
+  ///   How long between events before the counter is reset to zero
+  ///
+  /// \param[in] count_limit_
+  ///   How high the counter can reach before check() returns false
+  ///
+  RateLimiter(
+    std::chrono::steady_clock::duration period_limit_,
+    std::size_t count_limit_);
+
+  bool reached_limit() const;
+
+  std::chrono::steady_clock::duration period_limit() const;
+  RateLimiter& period_limit(std::chrono::steady_clock::duration new_limit);
+
+  std::size_t count_limit() const;
+  RateLimiter& count_limit(std::size_t new_limit);
+
+  class Implementation;
+private:
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+} // namespace rmf_utils
+
+#endif // RMF_UTILS__RATELIMITER_HPP

--- a/rmf_utils/src/rmf_utils/RateLimiter.cpp
+++ b/rmf_utils/src/rmf_utils/RateLimiter.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_utils/RateLimiter.hpp>
+
+#include <optional>
+
+namespace rmf_utils {
+
+//==============================================================================
+class RateLimiter::Implementation
+{
+public:
+
+  using Duration = std::chrono::steady_clock::duration;
+  using Time = std::chrono::steady_clock::time_point;
+
+  bool reached_limit() const
+  {
+    const auto now = std::chrono::steady_clock::now();
+    if (!last_call.has_value() || *last_call + period_limit < now)
+    {
+      last_call = now;
+      count = 1;
+      return false;
+    }
+
+    ++count;
+    return count_limit < count;
+  }
+
+  Duration period_limit;
+  std::size_t count_limit;
+  mutable std::size_t count = 0;
+  mutable std::optional<Time> last_call = std::nullopt;
+};
+
+//==============================================================================
+RateLimiter::RateLimiter(
+  std::chrono::steady_clock::duration period_limit_,
+  std::size_t count_limit_)
+  : _pimpl(rmf_utils::make_impl<Implementation>(
+        Implementation{period_limit_, count_limit_}))
+{
+  // Do nothing
+}
+
+//==============================================================================
+bool RateLimiter::reached_limit() const
+{
+  return _pimpl->reached_limit();
+}
+
+//==============================================================================
+std::chrono::steady_clock::duration RateLimiter::period_limit() const
+{
+  return _pimpl->period_limit;
+}
+
+//==============================================================================
+RateLimiter& RateLimiter::period_limit(std::chrono::steady_clock::duration l)
+{
+  _pimpl->period_limit = l;
+  return *this;
+}
+
+//==============================================================================
+std::size_t RateLimiter::count_limit() const
+{
+  return _pimpl->count_limit;
+}
+
+//==============================================================================
+RateLimiter& RateLimiter::count_limit(std::size_t l)
+{
+  _pimpl->count_limit = l;
+  return *this;
+}
+
+} // namespace rmf_utils


### PR DESCRIPTION
This adds a simple utility class that helps limit the rate of events. This can be used to detect if a pathological cycle of conflict is happening.