### PR TITLE
fix uncrustify test

### DIFF
--- a/rmf_utils/src/rmf_utils/RateLimiter.cpp
+++ b/rmf_utils/src/rmf_utils/RateLimiter.cpp
@@ -53,8 +53,8 @@ public:
 RateLimiter::RateLimiter(
   std::chrono::steady_clock::duration period_limit_,
   std::size_t count_limit_)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-        Implementation{period_limit_, count_limit_}))
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{period_limit_, count_limit_}))
 {
   // Do nothing
 }


### PR DESCRIPTION
Apparently the git action CI was disabled here previously and some uncrustify styling check was failing. The nightly CI test in `open-rmf/rmf` can be seen here https://github.com/open-rmf/rmf/pull/122. 

Simply re-enabled CI build, and fixed style.