### PR TITLE
Fix build with Apple Clang

### DIFF
--- a/rmf_utils/include/rmf_utils/Modular.hpp
+++ b/rmf_utils/include/rmf_utils/Modular.hpp
@@ -19,6 +19,7 @@
 #define RMF_UTILS__MODULAR_HPP
 
 #include <stdexcept>
+#include <string>
 #include <limits>
 #include <type_traits>
 


### PR DESCRIPTION
The default compiler on macOS devices is Apple Clang which throws an error for undefined `std::to_string()` call. This PR adds the `<string>` include to fix compilation.

```
/Users/yadunund/ws_rmf/install/rmf_utils/include/rmf_utils/Modular.hpp:64:22: error: no member named 'to_string' in namespace 'std'
              + std::to_string(Window));
 ```            